### PR TITLE
chore: update Elasticsearch version in test configuration to 8.19.10

### DIFF
--- a/src/test/java/au/org/aodn/oceancurrent/configuration/elasticsearch/ElasticsearchTestConfig.java
+++ b/src/test/java/au/org/aodn/oceancurrent/configuration/elasticsearch/ElasticsearchTestConfig.java
@@ -31,7 +31,7 @@ public class ElasticsearchTestConfig {
      */
     @Bean(initMethod = "start", destroyMethod = "stop")
     public ElasticsearchContainer elasticsearchContainer(
-            @Value("${elasticsearch.docker.elasticVersion:8.19.10}") String version
+            @Value("${elasticsearch.docker.elastic-version}") String version
     ) {
         ElasticsearchContainer container = new ElasticsearchContainer(
                 DockerImageName.parse(ELASTICSEARCH_IMAGE + version)

--- a/src/test/java/au/org/aodn/oceancurrent/configuration/elasticsearch/ElasticsearchTestConfig.java
+++ b/src/test/java/au/org/aodn/oceancurrent/configuration/elasticsearch/ElasticsearchTestConfig.java
@@ -31,7 +31,7 @@ public class ElasticsearchTestConfig {
      */
     @Bean(initMethod = "start", destroyMethod = "stop")
     public ElasticsearchContainer elasticsearchContainer(
-            @Value("${elasticsearch.docker.elasticVersion:8.17.4}") String version
+            @Value("${elasticsearch.docker.elasticVersion:8.19.10}") String version
     ) {
         ElasticsearchContainer container = new ElasticsearchContainer(
                 DockerImageName.parse(ELASTICSEARCH_IMAGE + version)

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -6,9 +6,10 @@ logging:
 management:
   endpoint:
     health:
-      enabled: false
+      access: none
   endpoints:
-    enabled-by-default: false
+    access:
+      default: none
 
 springdoc:
   api-docs:
@@ -24,7 +25,7 @@ elasticsearch:
       expression: 0 0 2 * * ? # every day at 2 AM in Australia/Hobart time
 
   docker:
-    elastic-version: 8.17.4 # Use the same version as in Elastic Cloud
+    elastic-version: 8.19.10 # Use the same version as in Elastic Cloud
 
 remote:
   base-url: "https://localhost:8080"


### PR DESCRIPTION
To align with the real elastic search cloud version for AODN